### PR TITLE
Tab-delimited output file

### DIFF
--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -283,10 +283,10 @@ namespace cgi
         if(e.countSeq >= parameters.minFragments)
         {
           outstrm << parameters.querySequences[queryFileNo]
-            << " " << parameters.refSequences[e.genomeId]
-            << " " << e.identity 
-            << " " << e.countSeq
-            << " " << totalQueryFragments
+            << "\t" << parameters.refSequences[e.genomeId]
+            << "\t" << e.identity 
+            << "\t" << e.countSeq
+            << "\t" << totalQueryFragments
             << "\n";
         }
       }


### PR DESCRIPTION
Dear all,
I suggest to write the ANI table in a tab-delimited format and not space-delimited. This format allows an easier reading from third-party tools or custom scripts, especially when the file paths contain spaces.