### PR TITLE
include <algorithm> in fastani_tests.cpp

### DIFF
--- a/tests/fastani_tests.cpp
+++ b/tests/fastani_tests.cpp
@@ -1,4 +1,5 @@
 
+#include <algorithm>
 #include <functional>
 #include <vector>
 #include <string>


### PR DESCRIPTION
Added `#include <algorithm>` to tests/fastani_tests.cpp.  Without this, with at least gcc 9.3.0 and 11.3.0 we get

```
[ 98%] Building CXX object CMakeFiles/fastANITest.dir/tests/fastani_tests.cpp.o
/sw/bioinfo/FastANI/1.34/src/FastANI/tests/fastani_tests.cpp: In function 'std::vector<std::__cxx11::basic_string<char> > get_file_contents(const string&)':
/sw/bioinfo/FastANI/1.34/src/FastANI/tests/fastani_tests.cpp:28:10: error: 'sort' is not a member of 'std'
   28 |     std::sort(file_contents.begin(), file_contents.end());
      |          ^~~~
make[2]: *** [CMakeFiles/fastANITest.dir/tests/fastani_tests.cpp.o] Error 1
```