### PR TITLE
Clarify threading works at reference genome level

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Using above commands, we get a plot file fastani.out.visual.pdf displayed below.
 
 ### Parallelization
 
-FastANI (v1.1 onwards) supports multi-threading, see the help page on how to configure thread count. To parallelize FastANI beyond single compute node, users also have the choice to simply divide their reference database into multiple chunks, and execute them as parallel processes. We provide a [script](scripts) in the repository to randomly split the database for this purpose.
+FastANI (v1.1 onwards) supports multi-threading where multiple reference genomes are provided, see the help page on how to configure thread count. To parallelize FastANI beyond a single compute node, users also have the choice to simply divide their list of reference databases into multiple chunks, and execute them as parallel processes. We provide a [script](scripts) in the repository to randomly split the database for this purpose.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Looking at the code in computeCoreIdentity.hpp and splitDatabase.sh it is clear that threading works at the level of reference genomes. This is a very natural implementation, however it was not clear from the README file that there is no benefit with a single reference genome.