### PR TITLE
Fix version displayed in CLI 1.33->1.34

### DIFF
--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -193,7 +193,7 @@ namespace skch
 
     if (versioncheck)
     {
-      std::cerr << "version 1.33\n\n";
+      std::cerr << "version 1.34\n\n";
       exit(0);
     }
 


### PR DESCRIPTION
## Issue

The version number displayed when running `fastANI -v` shows `version 1.33` instead of the expected version `1.34` after building FastANI v1.34.

## Changes

Updated the version string in src/map/include/parseCmdArgs.hpp to correctly display v1.34
