### PR TITLE
docs: improve CLI help organization and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(FastANI
     VERSION 1.34
     DESCRIPTION "Fast computation of whole-genome Average Nucleotide Identity (ANI)."
     LANGUAGES CXX)
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG -flto -march=native")
 #
 # Main executable
 add_executable(fastANI src/cgi/core_genome_identity.cpp src/cgi/main.cpp)

--- a/src/cgi/core_genome_identity.cpp
+++ b/src/cgi/core_genome_identity.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <functional>
 #include <omp.h>
+#include <memory>
 
 //Own includes
 #include "map/include/map_parameters.hpp"
@@ -17,23 +18,19 @@
 #include "map/include/winSketch.hpp"
 #include "map/include/computeMap.hpp"
 #include "map/include/commonFunc.hpp"
-#include "cgi/include/computeCoreIdentity.hpp" 
-
-inline bool file_exists (const std::string& name) {
-    std::ifstream f(name.c_str());
-    return f.good();
-}
+#include "cgi/include/computeCoreIdentity.hpp"
+#include "map/include/sketch_io.hpp"
 
 int core_genome_identity(int argc, char **argv)
 {
   /*
-   * Make sure env variable MALLOC_ARENA_MAX is unset 
+   * Make sure env variable MALLOC_ARENA_MAX is unset
    * for efficient multi-threaded execution
    */
   unsetenv((char *)"MALLOC_ARENA_MAX");
   using namespace std::placeholders;  // for _1, _2, _3...
 
-  //Parse command line arguements   
+  //Parse command line arguements
   skch::Parameters parameters;        //sketching and mapping parameters
   skch::parseandSave(argc, argv, parameters);
 
@@ -43,9 +40,9 @@ int core_genome_identity(int argc, char **argv)
   parameters.outFileName = "/dev/null";
 
   //Set up for parallel execution
-  omp_set_num_threads( parameters.threads ); 
-  std::vector <skch::Parameters> parameters_split (parameters.threads);
-  cgi::splitReferenceGenomes (parameters, parameters_split);
+  omp_set_num_threads(parameters.threads);
+  std::vector<skch::Parameters> parameters_split(parameters.threads);
+  cgi::splitReferenceGenomes(parameters, parameters_split);
 
   //Final output vectors of ANI computation (one per thread; merged after parallel region)
   std::vector< std::vector<cgi::CGI_Results> > finalResults_by_thread(parameters.threads);
@@ -56,69 +53,142 @@ int core_genome_identity(int argc, char **argv)
 #pragma omp parallel for schedule(static,1)
   for (uint64_t i = 0; i < parameters.threads; i++)
   {
-    if ( omp_get_thread_num() == 0)
-      std::cerr << "INFO [thread 0], skch::main, Count of threads executing parallel_for : " << omp_get_num_threads() << std::endl;
+    if (omp_get_thread_num() == 0)
+      std::cerr << "INFO [thread 0], skch::main, Count of threads executing parallel_for : "
+                << omp_get_num_threads() << std::endl;
 
     //start timer
     auto t0 = skch::Time::now();
 
-    //Build the sketch for reference
-    skch::Sketch referSketch(parameters_split[i]);
+    // Build or load the sketch for reference
+    std::unique_ptr<skch::Sketch> referSketchPtr;
+
+    if(parameters.loadSketchMode)
+    {
+      std::string inSketchFile =
+        parameters.sketchFile + "." + std::to_string(i);
+
+      referSketchPtr = std::make_unique<skch::Sketch>(
+          skch::loadReferenceSketch(parameters_split[i], inSketchFile));
+
+      std::cerr << "INFO [thread " << omp_get_thread_num()
+                << "], skch::main, loaded sketch from "
+                << inSketchFile << std::endl;
+    }
+    else
+    {
+      referSketchPtr = std::make_unique<skch::Sketch>(parameters_split[i]);
+    }
+
+    skch::Sketch &referSketch = *referSketchPtr;
+
+    // When loading from sketch, rebuild the per-split reference genome names
+    // needed later by outputCGI/outputPhylip.
+    if(parameters.loadSketchMode)
+    {
+      parameters_split[i].refSequences.clear();
+
+      size_t prev = 0;
+      for(size_t g = 0; g < referSketch.sequencesByFileInfo.size(); g++)
+      {
+        size_t end = static_cast<size_t>(referSketch.sequencesByFileInfo[g]);
+
+        std::string genomeName = "sketch_ref_" + std::to_string(g);
+        if(prev < referSketch.metadata.size())
+          genomeName = referSketch.metadata[prev].name;
+
+        parameters_split[i].refSequences.push_back(genomeName);
+        prev = end;
+      }
+    }
+
+    if(parameters.writeRefSketchMode)
+    {
+      std::string outSketchFile =
+        parameters.writeRefSketchFile + "." + std::to_string(i);
+
+      skch::saveReferenceSketch(referSketch, parameters_split[i], outSketchFile);
+
+      std::cerr << "INFO [thread " << omp_get_thread_num()
+                << "], skch::main, wrote sketch to "
+                << outSketchFile << std::endl;
+
+      continue;
+    }
 
     std::chrono::duration<double> timeRefSketch = skch::Time::now() - t0;
 
-    if ( omp_get_thread_num() == 0)
-      std::cerr << "INFO [thread 0], skch::main, Time spent sketching the reference : " << timeRefSketch.count() << " sec" << std::endl;
+    if (omp_get_thread_num() == 0)
+      std::cerr << "INFO [thread 0], skch::main, Time spent sketching the reference : "
+                << timeRefSketch.count() << " sec" << std::endl;
 
-
-      //Final output vector of ANI computation
+    //Final output vector of ANI computation
     std::vector<cgi::CGI_Results> finalResults_local;
 
     sanityCheck[i] = referSketch.sanityCheck(parameters.maxRatioDiff);
     ratioDiffs[i] = referSketch.getRatioDifference();
 
-    if(sanityCheck[i]){
-   //Loop over query genomes
-    for(uint64_t queryno = 0; queryno < parameters_split[i].querySequences.size(); queryno++)
+    if(sanityCheck[i])
     {
-      t0 = skch::Time::now();
+      //Loop over query genomes
+      for(uint64_t queryno = 0; queryno < parameters_split[i].querySequences.size(); queryno++)
+      {
+        t0 = skch::Time::now();
 
-      skch::MappingResultsVector_t mapResults;
-      uint64_t totalQueryFragments = 0;
+        skch::MappingResultsVector_t mapResults;
+        uint64_t totalQueryFragments = 0;
 
-      auto fn = std::bind(skch::Map::insertL2ResultsToVec, std::ref(mapResults), _1);
-      if ( omp_get_thread_num() == 0)
-        std::cerr << "INFO [thread 0], skch::main, Start Map " << queryno + 1 << std::endl;
-      skch::Map mapper = skch::Map(parameters_split[i], referSketch, totalQueryFragments, queryno, fn);
+        auto fn = std::bind(skch::Map::insertL2ResultsToVec, std::ref(mapResults), _1);
+        if (omp_get_thread_num() == 0)
+          std::cerr << "INFO [thread 0], skch::main, Start Map " << queryno + 1 << std::endl;
 
-      std::chrono::duration<double> timeMapQuery = skch::Time::now() - t0;
+        skch::Map mapper = skch::Map(parameters_split[i], referSketch, totalQueryFragments, queryno, fn);
 
-      if ( omp_get_thread_num() == 0)
-        std::cerr << "INFO [thread 0], skch::main, Time spent mapping fragments in query #" << queryno + 1 <<  " : " << timeMapQuery.count() << " sec" << std::endl;
+        std::chrono::duration<double> timeMapQuery = skch::Time::now() - t0;
 
-      t0 = skch::Time::now();
+        if (omp_get_thread_num() == 0)
+          std::cerr << "INFO [thread 0], skch::main, Time spent mapping fragments in query #"
+                    << queryno + 1 << " : " << timeMapQuery.count() << " sec" << std::endl;
 
-      cgi::computeCGI(parameters_split[i], mapResults, mapper, referSketch, totalQueryFragments, queryno, fileName, finalResults_local);
+        t0 = skch::Time::now();
 
-      std::chrono::duration<double> timeCGI = skch::Time::now() - t0;
+        cgi::computeCGI(parameters_split[i], mapResults, mapper, referSketch,
+                        totalQueryFragments, queryno, fileName, finalResults_local);
 
-      if ( omp_get_thread_num() == 0)
-        std::cerr << "INFO [thread 0], skch::main, Time spent post mapping : " << timeCGI.count() << " sec" << std::endl;
+        std::chrono::duration<double> timeCGI = skch::Time::now() - t0;
+
+        if (omp_get_thread_num() == 0)
+          std::cerr << "INFO [thread 0], skch::main, Time spent post mapping : "
+                    << timeCGI.count() << " sec" << std::endl;
+      }
     }
 
-    }
+    cgi::correctRefGenomeIds(finalResults_local);
 
-      cgi::correctRefGenomeIds (finalResults_local);
+    // Store this thread's results without locking; merge after parallel region
+    finalResults_by_thread[i] = std::move(finalResults_local);
 
-      cgi::correctRefGenomeIds (finalResults_local);
-
-      // Store this thread's results without locking; merge after parallel region
-      finalResults_by_thread[i] = std::move(finalResults_local);
-
-      std::cerr << "INFO [thread " << omp_get_thread_num() << "], skch::main, ready to exit the loop" << std::endl;
+    std::cerr << "INFO [thread " << omp_get_thread_num()
+              << "], skch::main, ready to exit the loop" << std::endl;
   }
 
   std::cerr << "INFO, skch::main, parallel_for execution finished" << std::endl;
+
+  if(parameters.loadSketchMode)
+  {
+    parameters.refSequences.clear();
+  
+    for(uint64_t i = 0; i < parameters.threads; i++)
+    {
+      for(const auto &name : parameters_split[i].refSequences)
+      {
+        parameters.refSequences.push_back(name);
+      }
+    }
+  }
+
+  if(parameters.writeRefSketchMode)
+    return 0;
 
   // Merge per-thread results (single-threaded, deterministic)
   std::vector<cgi::CGI_Results> finalResults;
@@ -131,46 +201,54 @@ int core_genome_identity(int argc, char **argv)
   for(auto &v : finalResults_by_thread)
     finalResults.insert(finalResults.end(), v.begin(), v.end());
 
-  for(auto i = 0; i < parameters.threads;i++){
-      if(sanityCheck[i] == false){
-          std::cerr << "ERROR :: SPLIT " << i << "'s ratio difference " << ratioDiffs[i]
-                    << " exceeds maximum thresholds." << std::endl;
-      }
+  for(auto i = 0; i < parameters.threads; i++)
+  {
+    if(sanityCheck[i] == false)
+    {
+      std::cerr << "ERROR :: SPLIT " << i << "'s ratio difference "
+                << ratioDiffs[i] << " exceeds maximum thresholds." << std::endl;
+    }
   }
 
-  std::unordered_map <std::string, uint64_t> genomeLengths;    // name of genome -> length
+  std::unordered_map<std::string, uint64_t> genomeLengths;
   cgi::computeGenomeLengths(parameters, genomeLengths);
 
   //report output in file
-  cgi::outputCGI (parameters, genomeLengths, finalResults, fileName);
+  cgi::outputCGI(parameters, genomeLengths, finalResults, fileName);
 
   //report output as matrix
-  if (parameters.matrixOutput)
-    cgi::outputPhylip (parameters, genomeLengths, finalResults, fileName);
+  if(parameters.matrixOutput)
+    cgi::outputPhylip(parameters, genomeLengths, finalResults, fileName);
 
-  if (parameters.visualize && parameters.threads > 1){
-      std::string outVisFile = fileName + ".visual";
-      std::ofstream ofile(outVisFile);
-      for(int i =0 ; i < parameters.threads; i++){
-          std::string visFileName = fileName + ".visual" + std::to_string(i);
-          std::ifstream ifile(visFileName);
-          if(!ifile.good()){
-              ifile.close();
-              continue;
-          }
-          const int BUFFER_SIZE = 4096;
-          std::vector<char> buffer (BUFFER_SIZE +1,0);
-          while (true) {
-              ifile.read(buffer.data(), BUFFER_SIZE);
-              std::streamsize s = ((ifile) ? BUFFER_SIZE : ifile.gcount());
-              buffer[s] = 0;
-              ofile << buffer.data();
-              if(!ifile) break;
-          }
-          ifile.close();
-          unlink(visFileName.c_str());
+  if(parameters.visualize && parameters.threads > 1)
+  {
+    std::string outVisFile = fileName + ".visual";
+    std::ofstream ofile(outVisFile);
+    for(int i = 0; i < parameters.threads; i++)
+    {
+      std::string visFileName = fileName + ".visual" + std::to_string(i);
+      std::ifstream ifile(visFileName);
+      if(!ifile.good())
+      {
+        ifile.close();
+        continue;
       }
-      ofile.close();
+
+      const int BUFFER_SIZE = 4096;
+      std::vector<char> buffer(BUFFER_SIZE + 1, 0);
+      while(true)
+      {
+        ifile.read(buffer.data(), BUFFER_SIZE);
+        std::streamsize s = ((ifile) ? BUFFER_SIZE : ifile.gcount());
+        buffer[s] = 0;
+        ofile << buffer.data();
+        if(!ifile) break;
+      }
+      ifile.close();
+      unlink(visFileName.c_str());
+    }
+    ofile.close();
   }
+
   return 0;
 }

--- a/src/cgi/core_genome_identity.cpp
+++ b/src/cgi/core_genome_identity.cpp
@@ -47,8 +47,9 @@ int core_genome_identity(int argc, char **argv)
   std::vector <skch::Parameters> parameters_split (parameters.threads);
   cgi::splitReferenceGenomes (parameters, parameters_split);
 
-  //Final output vector of ANI computation
-  std::vector<cgi::CGI_Results> finalResults;
+  //Final output vectors of ANI computation (one per thread; merged after parallel region)
+  std::vector< std::vector<cgi::CGI_Results> > finalResults_by_thread(parameters.threads);
+
   std::vector<bool> sanityCheck(parameters.threads, true);
   std::vector<float> ratioDiffs(parameters.threads, true);
 
@@ -109,18 +110,26 @@ int core_genome_identity(int argc, char **argv)
 
       cgi::correctRefGenomeIds (finalResults_local);
 
-#pragma omp critical
-    {
-      finalResults.insert (finalResults.end(), finalResults_local.begin(), finalResults_local.end());
-    }
+      cgi::correctRefGenomeIds (finalResults_local);
 
-#pragma omp critical
-    {
+      // Store this thread's results without locking; merge after parallel region
+      finalResults_by_thread[i] = std::move(finalResults_local);
+
       std::cerr << "INFO [thread " << omp_get_thread_num() << "], skch::main, ready to exit the loop" << std::endl;
-    }
   }
 
   std::cerr << "INFO, skch::main, parallel_for execution finished" << std::endl;
+
+  // Merge per-thread results (single-threaded, deterministic)
+  std::vector<cgi::CGI_Results> finalResults;
+
+  size_t total = 0;
+  for(const auto &v : finalResults_by_thread)
+    total += v.size();
+  finalResults.reserve(total);
+
+  for(auto &v : finalResults_by_thread)
+    finalResults.insert(finalResults.end(), v.begin(), v.end());
 
   for(auto i = 0; i < parameters.threads;i++){
       if(sanityCheck[i] == false){

--- a/src/cgi/include/cgid_types.hpp
+++ b/src/cgi/include/cgid_types.hpp
@@ -72,9 +72,15 @@ namespace cgi
     skch::seqno_t countSeq;
     skch::seqno_t totalQueryFragments;
     float identity;
-
+  
+    float frac99 = 0.0f;
+    float sdAni = 0.0f;
+    float q1Ani = 0.0f;
+    float medianAni = 0.0f;
+    float q3Ani = 0.0f;
+  
     bool operator <(const CGI_Results& x) const {
-      return std::tie(x.qryGenomeId, identity) 
+      return std::tie(x.qryGenomeId, identity)
         < std::tie(qryGenomeId, x.identity);
     }
   };

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -70,6 +70,7 @@ void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::S
     {
       //Open the file using kseq
       gzFile fp = gzopen(e.c_str(), "r");
+      gzbuffer(fp, 1 << 20);  // 1MB read buffer
       kseq_t *seq = kseq_init(fp);
       int l; uint64_t genomeLen = 0;
 
@@ -92,12 +93,13 @@ void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::S
       {
         //Open the file using kseq
         gzFile fp = gzopen(e.c_str(), "r");
+        gzbuffer(fp, 1 << 20);  // 1MB read buffer
         kseq_t *seq = kseq_init(fp);
         int l; uint64_t genomeLen = 0;
 
       while ((l = kseq_read(seq)) >= 0) {
         if (l >= parameters.minReadLength) {
-          uint64_t _l_ = (((uint64_t)strlen(seq->seq.s)) / parameters.minReadLength) * parameters.minReadLength;
+          uint64_t _l_ = (((uint64_t)seq->seq.l) / parameters.minReadLength) * parameters.minReadLength;
           genomeLen = genomeLen + _l_;
         }
       }

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -28,37 +28,46 @@ namespace cgi
    *                              and revise reference ids to genome id
    * @param[in/out] shortResults
    */
-void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::Sketch &refSketch)
-{
-  // Cache contig->genome mapping to avoid rebuilding every call.
-  // Safe because it depends only on the reference sketch (contig count + sequencesByFileInfo).
-  static thread_local std::vector<int> contigToGenomeId;
-
-  const size_t numContigs = refSketch.metadata.size();
-
-  // (Re)build only if size changed (e.g., different reference set)
-  if(contigToGenomeId.size() != numContigs)
+  void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults,
+                             skch::Sketch &refSketch)
   {
-    contigToGenomeId.assign(numContigs, -1);
-
-    size_t start = 0;
-    for(size_t genomeId = 0; genomeId < refSketch.sequencesByFileInfo.size(); genomeId++)
-    {
-      const size_t end = static_cast<size_t>(refSketch.sequencesByFileInfo[genomeId]);
-      for(size_t contigId = start; contigId < end && contigId < numContigs; contigId++)
-        contigToGenomeId[contigId] = static_cast<int>(genomeId);
-      start = end;
-    }
+      static thread_local std::vector<int> contigToGenomeId;
+  
+      const size_t numContigs = refSketch.metadata.size();
+  
+      if (contigToGenomeId.size() != numContigs)
+      {
+          contigToGenomeId.assign(numContigs, -1);
+  
+          size_t start = 0;
+          for (size_t genomeId = 0;
+               genomeId < refSketch.sequencesByFileInfo.size();
+               genomeId++)
+          {
+              const size_t end =
+                  static_cast<size_t>(refSketch.sequencesByFileInfo[genomeId]);
+  
+              for (size_t contigId = start;
+                   contigId < end && contigId < numContigs;
+                   contigId++)
+              {
+                  contigToGenomeId[contigId] =
+                      static_cast<int>(genomeId);
+              }
+  
+              start = end;
+          }
+      }
+  
+      for (auto &r : shortResults)
+      {
+          const size_t contigId =
+              static_cast<size_t>(r.refSequenceId);
+  
+          if (contigId < contigToGenomeId.size())
+              r.genomeId = contigToGenomeId[contigId];
+      }
   }
-
-  // Revise genomeId in results (O(1) per result)
-  for(auto &r : shortResults)
-  {
-    const auto contigId = static_cast<size_t>(r.refSequenceId);
-    if(contigId < contigToGenomeId.size())
-      r.genomeId = contigToGenomeId[contigId];
-  }
-}
 
   /**
    * @brief                       compute genome lengths in reference and query genome set
@@ -76,7 +85,7 @@ void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::S
 
       while ((l = kseq_read(seq)) >= 0) {
         if (l >= parameters.minReadLength) {
-          uint64_t _l_ = (((uint64_t)strlen(seq->seq.s)) / parameters.minReadLength) * parameters.minReadLength;
+          uint64_t _l_ = (((uint64_t)seq->seq.l) / parameters.minReadLength) * parameters.minReadLength;
           genomeLen = genomeLen + _l_;
         }
       }
@@ -223,34 +232,30 @@ void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::S
      */
     reviseRefIdToGenomeId(shortResults, refSketch);
 
-
-    //We need best reciprocal identity match for each genome, query pair
     std::vector<MappingResult_CGI> mappings_1way;
     std::vector<MappingResult_CGI> mappings_2way;
 
-    ///1. Code below fetches best identity match for each genome, query pair
-    //For each query sequence, best match in the reference is preserved
+    // --- Stage 1: best match per genome/query pair ---
+    std::sort(shortResults.begin(), shortResults.end(), cmp_query_bucket);
+    
+    for(auto &e : shortResults)
     {
-      //Sort the vector shortResults
-      std::sort(shortResults.begin(), shortResults.end(), cmp_query_bucket);
-
-      for(auto &e : shortResults)
-      {
         if(mappings_1way.empty())
-          mappings_1way.push_back(e);
-
-        else if ( !(
-              e.genomeId == mappings_1way.back().genomeId && 
-              e.querySeqId == mappings_1way.back().querySeqId))
+            mappings_1way.push_back(e);
+    
+        else if(!(e.genomeId == mappings_1way.back().genomeId &&
+                  e.querySeqId == mappings_1way.back().querySeqId))
         {
-          mappings_1way.emplace_back(e);
+            mappings_1way.emplace_back(e);
         }
         else
         {
-          mappings_1way.back() = e;
+            mappings_1way.back() = e;
         }
-      }
     }
+
+    // std::cerr << "DEBUG: mappings_2way size (initial) = "
+    //       << mappings_2way.size() << std::endl;
 
     ///2. Now, we compute 2-way ANI
     //For each mapped region, and within a reference bin bucket, single best query mapping is preserved

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -96,12 +96,13 @@ namespace cgi
       gzclose(fp); //close the file handler 
     }
 
-    for(auto &e : parameters.refSequences)
+    if(!parameters.loadSketchMode)
     {
-      if( genomeLengths.find(e) == genomeLengths.end() )
+      for(auto &e : parameters.refSequences)
       {
-        //Open the file using kseq
-        gzFile fp = gzopen(e.c_str(), "r");
+        if( genomeLengths.find(e) == genomeLengths.end() )
+        {
+          gzFile fp = gzopen(e.c_str(), "r");
         gzbuffer(fp, 1 << 20);  // 1MB read buffer
         kseq_t *seq = kseq_init(fp);
         int l; uint64_t genomeLen = 0;
@@ -120,6 +121,7 @@ namespace cgi
       }
     }
   }
+}
 
   /**
    * @brief                             output blast tabular mappings for visualization 

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -28,18 +28,37 @@ namespace cgi
    *                              and revise reference ids to genome id
    * @param[in/out] shortResults
    */
-  void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::Sketch &refSketch)
-  {
-    for(auto &e : shortResults)
-    {
-      auto referenceSequenceId = e.refSequenceId;
-      auto upperRangeIter = std::upper_bound(refSketch.sequencesByFileInfo.begin(), 
-          refSketch.sequencesByFileInfo.end(),
-          referenceSequenceId);
+void reviseRefIdToGenomeId(std::vector<MappingResult_CGI> &shortResults, skch::Sketch &refSketch)
+{
+  // Cache contig->genome mapping to avoid rebuilding every call.
+  // Safe because it depends only on the reference sketch (contig count + sequencesByFileInfo).
+  static thread_local std::vector<int> contigToGenomeId;
 
-      e.genomeId = std::distance(refSketch.sequencesByFileInfo.begin(), upperRangeIter);
+  const size_t numContigs = refSketch.metadata.size();
+
+  // (Re)build only if size changed (e.g., different reference set)
+  if(contigToGenomeId.size() != numContigs)
+  {
+    contigToGenomeId.assign(numContigs, -1);
+
+    size_t start = 0;
+    for(size_t genomeId = 0; genomeId < refSketch.sequencesByFileInfo.size(); genomeId++)
+    {
+      const size_t end = static_cast<size_t>(refSketch.sequencesByFileInfo[genomeId]);
+      for(size_t contigId = start; contigId < end && contigId < numContigs; contigId++)
+        contigToGenomeId[contigId] = static_cast<int>(genomeId);
+      start = end;
     }
   }
+
+  // Revise genomeId in results (O(1) per result)
+  for(auto &r : shortResults)
+  {
+    const auto contigId = static_cast<size_t>(r.refSequenceId);
+    if(contigId < contigToGenomeId.size())
+      r.genomeId = contigToGenomeId[contigId];
+  }
+}
 
   /**
    * @brief                       compute genome lengths in reference and query genome set

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -403,6 +403,26 @@ namespace cgi
 
     std::ofstream outstrm(fileName);
 
+    if(parameters.header)
+    {
+      outstrm << "Query"
+              << "\t" << "Reference"
+              << "\t" << "ANI"
+              << "\t" << "MatchedFragments"
+              << "\t" << "TotalQueryFragments";
+    
+      if(parameters.extendedMetrics)
+      {
+        outstrm << "\t" << "Frac99"
+                << "\t" << "SdANI"
+                << "\t" << "Q1"
+                << "\t" << "Median"
+                << "\t" << "Q3";
+      }
+    
+      outstrm << "\n";
+    }
+
     //Report results
     for(auto &e : CGI_ResultsVector)
     {

--- a/src/cgi/include/computeCoreIdentity.hpp
+++ b/src/cgi/include/computeCoreIdentity.hpp
@@ -10,8 +10,9 @@
 #include <algorithm>
 #include <unordered_map>
 #include <fstream>
+#include <cmath>
 #include <omp.h>
-#include <zlib.h>  
+#include <zlib.h>
 
 //Own includes
 #include "map/include/base_types.hpp"
@@ -195,6 +196,40 @@ namespace cgi
    * @param[in]   fileName              file name where results will be reported
    * @param[out]  CGI_ResultsVector     FastANI results
    */
+
+  inline float percentileFromSorted(const std::vector<float> &vals, double p)
+  {
+    if(vals.empty())
+      return 0.0f;
+  
+    if(vals.size() == 1)
+      return vals[0];
+  
+    double idx = p * (vals.size() - 1);
+    size_t lo = static_cast<size_t>(std::floor(idx));
+    size_t hi = static_cast<size_t>(std::ceil(idx));
+  
+    if(lo == hi)
+      return vals[lo];
+  
+    double frac = idx - lo;
+    return static_cast<float>(vals[lo] + frac * (vals[hi] - vals[lo]));
+  }
+  
+  inline float computeStdDev(const std::vector<float> &vals, float mean)
+  {
+    if(vals.size() <= 1)
+      return 0.0f;
+  
+    double sumSq = 0.0;
+    for(float v : vals)
+    {
+      double d = v - mean;
+      sumSq += d * d;
+    }
+  
+    return static_cast<float>(std::sqrt(sumSq / vals.size()));
+  }
   void computeCGI(skch::Parameters &parameters,
       skch::MappingResultsVector_t &results,
       skch::Map &mapper,
@@ -295,32 +330,58 @@ namespace cgi
     for(auto it = mappings_2way.begin(); it != mappings_2way.end();)
     {
       skch::seqno_t currentGenomeId = it->genomeId;
-
-      //Bucket by genome id
-      auto rangeEndIter = std::find_if(it, mappings_2way.end(), [&](const MappingResult_CGI& e) 
-          { 
-            return e.genomeId != currentGenomeId; 
-          } );
-
-      float sumIdentity = 0.0;
-
-      for(auto it2 = it; it2 != rangeEndIter; it2++)
+    
+      // Bucket by genome id
+      auto rangeEndIter = std::find_if(
+          it,
+          mappings_2way.end(),
+          [&](const MappingResult_CGI& e)
+          {
+            return e.genomeId != currentGenomeId;
+          });
+    
+      float sumIdentity = 0.0f;
+      std::vector<float> fragmentAnis;
+      fragmentAnis.reserve(std::distance(it, rangeEndIter));
+    
+      skch::seqno_t countGe99 = 0;
+    
+      for(auto it2 = it; it2 != rangeEndIter; ++it2)
       {
         sumIdentity += it2->nucIdentity;
+        fragmentAnis.push_back(it2->nucIdentity);
+    
+        if(it2->nucIdentity >= 99.0f)
+          countGe99++;
       }
-
-      //Save the result 
+    
+      // Save the result
       CGI_Results currentResult;
-
+    
       currentResult.qryGenomeId = queryFileNo;
       currentResult.refGenomeId = currentGenomeId;
       currentResult.countSeq = std::distance(it, rangeEndIter);
       currentResult.totalQueryFragments = totalQueryFragments;
-      currentResult.identity = sumIdentity/currentResult.countSeq;
-
+      currentResult.identity = sumIdentity / currentResult.countSeq;
+    
+      if(parameters.extendedMetrics)
+      {
+        std::sort(fragmentAnis.begin(), fragmentAnis.end());
+    
+        currentResult.frac99 =
+          (currentResult.totalQueryFragments > 0)
+          ? static_cast<float>(countGe99) / static_cast<float>(currentResult.totalQueryFragments)
+          : 0.0f;
+    
+        currentResult.sdAni = computeStdDev(fragmentAnis, currentResult.identity);
+        currentResult.q1Ani = percentileFromSorted(fragmentAnis, 0.25);
+        currentResult.medianAni = percentileFromSorted(fragmentAnis, 0.50);
+        currentResult.q3Ani = percentileFromSorted(fragmentAnis, 0.75);
+      }
+    
       CGI_ResultsVector.push_back(currentResult);
-
-      //Advance the iterator it
+    
+      // Advance the iterator
       it = rangeEndIter;
     }
   }
@@ -361,10 +422,20 @@ namespace cgi
       {
         outstrm << qryGenome
           << "\t" << refGenome
-          << "\t" << e.identity 
+          << "\t" << e.identity
           << "\t" << e.countSeq
-          << "\t" << e.totalQueryFragments
-          << "\n";
+          << "\t" << e.totalQueryFragments;
+        
+        if(parameters.extendedMetrics)
+        {
+          outstrm << "\t" << e.frac99
+                  << "\t" << e.sdAni
+                  << "\t" << e.q1Ani
+                  << "\t" << e.medianAni
+                  << "\t" << e.q3Ani;
+        }
+        
+        outstrm << "\n";
       }
     }
 

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -88,83 +88,88 @@ namespace skch
      * @param[in]   windowSize
      * @param[in]   seqCounter      current sequence number, used while saving the position of minimizer
      */
-    template <typename T, typename KSEQ>
-      inline void addMinimizers(std::vector<T> &minimizerIndex, KSEQ kseq, int kmerSize, 
-          int windowSize,
-          int alphabetSize,
-          seqno_t seqCounter)
+template <typename T, typename KSEQ>
+  inline void addMinimizers(std::vector<T> &minimizerIndex, KSEQ kseq, int kmerSize, 
+      int windowSize,
+      int alphabetSize,
+      seqno_t seqCounter)
+{
+  /**
+   * Double-ended queue (saves minimum at front end)
+   * Saves pair of the minimizer and the position of hashed kmer in the sequence
+   * Position of kmer is required to discard kmers that fall out of current window
+   */
+  std::deque< std::pair<MinimizerInfo, offset_t> > Q;
+
+  makeUpperCase(kseq);
+
+  //length of the sequencd
+  offset_t len = kseq->seq.l;
+
+  //Compute reverse complement of seq (reuse buffer to avoid per-call heap alloc)
+  static thread_local std::vector<char> seqRevBuf;
+  char *seqRev = nullptr;
+
+  if(alphabetSize == 4) //not protein
+  {
+    if(seqRevBuf.size() < static_cast<size_t>(len))
+      seqRevBuf.resize(static_cast<size_t>(len));
+    seqRev = seqRevBuf.data();
+
+    CommonFunc::reverseComplement(kseq->seq.s, seqRev, len);
+  }
+
+  for(offset_t i = 0; i < len - kmerSize + 1; i++)
+  {
+    //The serial number of current sliding window
+    //First valid window appears when i = windowSize - 1
+    offset_t currentWindowId = i - windowSize + 1;
+
+    //Hash kmers
+    hash_t hashFwd = CommonFunc::getHash(kseq->seq.s + i, kmerSize); 
+    hash_t hashBwd;
+
+    if(alphabetSize == 4)
+      hashBwd = CommonFunc::getHash(seqRev + len - i - kmerSize, kmerSize);
+    else  //proteins
+      hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
+
+    //Consider non-symmetric kmers only
+    if(hashBwd != hashFwd)
+    {
+      //Take minimum value of kmer and its reverse complement
+      hash_t currentKmer = std::min(hashFwd, hashBwd);
+
+      //If front minimum is not in the current window, remove it
+      while(!Q.empty() && Q.front().second <=  i - windowSize)
+        Q.pop_front();
+
+      //Hashes less than equal to currentKmer are not required
+      //Remove them from Q (back)
+      while(!Q.empty() && Q.back().first.hash >= currentKmer) 
+        Q.pop_back();
+
+      //Push currentKmer and position to back of the queue
+      //-1 indicates the dummy window # (will be updated later)
+      Q.push_back( std::make_pair(
+            MinimizerInfo{currentKmer, seqCounter, -1},
+            i)); 
+
+      //Select the minimizer from Q and put into index
+      if(currentWindowId >= 0)
       {
-        /**
-         * Double-ended queue (saves minimum at front end)
-         * Saves pair of the minimizer and the position of hashed kmer in the sequence
-         * Position of kmer is required to discard kmers that fall out of current window
-         */
-        std::deque< std::pair<MinimizerInfo, offset_t> > Q;
-
-        makeUpperCase(kseq);
-
-        //length of the sequencd
-        offset_t len = kseq->seq.l;
-
-        //Compute reverse complement of seq
-        char *seqRev = new char[len];
-
-        if(alphabetSize == 4) //not protein
-          CommonFunc::reverseComplement(kseq->seq.s, seqRev, len);
-
-        for(offset_t i = 0; i < len - kmerSize + 1; i++)
+        //We save the minimizer if we are seeing it for first time
+        if(minimizerIndex.empty() || minimizerIndex.back() != Q.front().first)
         {
-          //The serial number of current sliding window
-          //First valid window appears when i = windowSize - 1
-          offset_t currentWindowId = i - windowSize + 1;
-
-          //Hash kmers
-          hash_t hashFwd = CommonFunc::getHash(kseq->seq.s + i, kmerSize); 
-          hash_t hashBwd;
-
-          if(alphabetSize == 4)
-            hashBwd = CommonFunc::getHash(seqRev + len - i - kmerSize, kmerSize);
-          else  //proteins
-            hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
-
-          //Consider non-symmetric kmers only
-          if(hashBwd != hashFwd)
-          {
-            //Take minimum value of kmer and its reverse complement
-            hash_t currentKmer = std::min(hashFwd, hashBwd);
-
-            //If front minimum is not in the current window, remove it
-            while(!Q.empty() && Q.front().second <=  i - windowSize)
-              Q.pop_front();
-
-            //Hashes less than equal to currentKmer are not required
-            //Remove them from Q (back)
-            while(!Q.empty() && Q.back().first.hash >= currentKmer) 
-              Q.pop_back();
-
-            //Push currentKmer and position to back of the queue
-            //-1 indicates the dummy window # (will be updated later)
-            Q.push_back( std::make_pair(
-                  MinimizerInfo{currentKmer, seqCounter, -1},
-                  i)); 
-
-            //Select the minimizer from Q and put into index
-            if(currentWindowId >= 0)
-            {
-              //We save the minimizer if we are seeing it for first time
-              if(minimizerIndex.empty() || minimizerIndex.back() != Q.front().first)
-              {
-                //Update the window position in this minimizer
-                //This step also ensures we don't re-insert the same minimizer again
-                Q.front().first.wpos = currentWindowId;     
-                minimizerIndex.push_back(Q.front().first);
-              }
-            }
-          }
+          //Update the window position in this minimizer
+          //This step also ensures we don't re-insert the same minimizer again
+          Q.front().first.wpos = currentWindowId;     
+          minimizerIndex.push_back(Q.front().first);
         }
-
-        delete [] seqRev;
       }
+    }
+  }
+}
 
     /**
      * @brief       overloaded function for case where seq. counter does not matter

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -101,7 +101,16 @@ template <typename T, typename KSEQ>
    */
   std::deque< std::pair<MinimizerInfo, offset_t> > Q;
 
-  makeUpperCase(kseq);
+  // PERF: avoid uppercasing if sequence already appears uppercase
+  bool needsUpper = false;
+  const int scan = std::min<int>(kseq->seq.l, 4096);
+  for(int j = 0; j < scan; j++)
+  {
+    char c = kseq->seq.s[j];
+    if(c >= 'a' && c <= 'z') { needsUpper = true; break; }
+  }
+  if(needsUpper)
+    makeUpperCase(kseq);
 
   //length of the sequencd
   offset_t len = kseq->seq.l;

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -88,18 +88,29 @@ namespace skch
      * @param[in]   windowSize
      * @param[in]   seqCounter      current sequence number, used while saving the position of minimizer
      */
+    
 template <typename T, typename KSEQ>
-  inline void addMinimizers(std::vector<T> &minimizerIndex, KSEQ kseq, int kmerSize, 
+  inline void addMinimizers(std::vector<T> &minimizerIndex, KSEQ kseq, int kmerSize,
       int windowSize,
       int alphabetSize,
       seqno_t seqCounter)
 {
   /**
    * Double-ended queue (saves minimum at front end)
-   * Saves pair of the minimizer and the position of hashed kmer in the sequence
-   * Position of kmer is required to discard kmers that fall out of current window
+   * Stores only the information actually needed while the kmer lives in the
+   * current window:
+   *   - hash value
+   *   - kmer position in the sequence
+   *   - window position when this minimizer was last emitted (-1 until emitted)
    */
-  std::deque< std::pair<MinimizerInfo, offset_t> > Q;
+  struct WindowMinimizer
+  {
+    hash_t hash;
+    offset_t kmerPos;
+    offset_t emittedWpos;
+  };
+
+  std::deque<WindowMinimizer> Q;
 
   // PERF: avoid uppercasing if sequence already appears uppercase
   bool needsUpper = false;
@@ -112,8 +123,14 @@ template <typename T, typename KSEQ>
   if(needsUpper)
     makeUpperCase(kseq);
 
-  //length of the sequencd
+  //length of the sequence
   offset_t len = kseq->seq.l;
+
+  // Reserve an upper bound on emitted minimizers for this sequence to reduce
+  // vector growth during the hot loop.
+  const offset_t reserveCount = std::max<offset_t>(0, len - kmerSize - windowSize + 2);
+  if(reserveCount > 0)
+    minimizerIndex.reserve(minimizerIndex.size() + static_cast<size_t>(reserveCount));
 
   //Compute reverse complement of seq (reuse buffer to avoid per-call heap alloc)
   static thread_local std::vector<char> seqRevBuf;
@@ -135,7 +152,7 @@ template <typename T, typename KSEQ>
     offset_t currentWindowId = i - windowSize + 1;
 
     //Hash kmers
-    hash_t hashFwd = CommonFunc::getHash(kseq->seq.s + i, kmerSize); 
+    hash_t hashFwd = CommonFunc::getHash(kseq->seq.s + i, kmerSize);
     hash_t hashBwd;
 
     if(alphabetSize == 4)
@@ -150,30 +167,30 @@ template <typename T, typename KSEQ>
       hash_t currentKmer = std::min(hashFwd, hashBwd);
 
       //If front minimum is not in the current window, remove it
-      while(!Q.empty() && Q.front().second <=  i - windowSize)
+      while(!Q.empty() && Q.front().kmerPos <= i - windowSize)
         Q.pop_front();
 
       //Hashes less than equal to currentKmer are not required
       //Remove them from Q (back)
-      while(!Q.empty() && Q.back().first.hash >= currentKmer) 
+      while(!Q.empty() && Q.back().hash >= currentKmer)
         Q.pop_back();
 
       //Push currentKmer and position to back of the queue
       //-1 indicates the dummy window # (will be updated later)
-      Q.push_back( std::make_pair(
-            MinimizerInfo{currentKmer, seqCounter, -1},
-            i)); 
+      Q.push_back(WindowMinimizer{currentKmer, i, -1});
 
       //Select the minimizer from Q and put into index
       if(currentWindowId >= 0)
       {
+        const MinimizerInfo frontInfo{Q.front().hash, seqCounter, Q.front().emittedWpos};
+
         //We save the minimizer if we are seeing it for first time
-        if(minimizerIndex.empty() || minimizerIndex.back() != Q.front().first)
+        if(minimizerIndex.empty() || minimizerIndex.back() != frontInfo)
         {
           //Update the window position in this minimizer
           //This step also ensures we don't re-insert the same minimizer again
-          Q.front().first.wpos = currentWindowId;     
-          minimizerIndex.push_back(Q.front().first);
+          Q.front().emittedWpos = currentWindowId;
+          minimizerIndex.push_back(MinimizerInfo{Q.front().hash, seqCounter, currentWindowId});
         }
       }
     }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -526,11 +526,14 @@ namespace skch
       {
         float bestNucIdentity = 0;
 
-        //Scan through the mappings to check best identity mapping
-        for(auto &e : l2Mappings)
+        //Only compute best identity when we need the "top 1%" filter
+        if(!param.reportAll)
         {
-          if(e.nucIdentity > bestNucIdentity)
-            bestNucIdentity = e.nucIdentity;
+          for(auto &e : l2Mappings)
+          {
+            if(e.nucIdentity > bestNucIdentity)
+              bestNucIdentity = e.nucIdentity;
+          }
         }
 
         //Print the results

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -468,10 +468,10 @@ namespace skch
 
           int beginOptimalPos, lastOptimalPos;
 
-          while ( std::distance(mi_L2iter.sw_end, lastSuperWindowRangeEnd) > 0)
+          while (mi_L2iter.sw_end != lastSuperWindowRangeEnd)
           {
-            assert( std::distance(mi_L2iter.sw_beg, firstSuperWindowRangeStart) <= 0);
-            assert( std::distance(mi_L2iter.sw_end, lastSuperWindowRangeEnd  ) >= 0);
+            assert(mi_L2iter.sw_beg <= firstSuperWindowRangeStart);
+            assert(mi_L2iter.sw_end >= lastSuperWindowRangeEnd);
 
             //Check if the previous first minimizer is out of current range
             if (prev_beg_iter != mi_L2iter.sw_beg)

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -158,8 +158,10 @@ namespace skch
               MappingResultsVector_t l2Mappings;
               l2Mappings.reserve(8);
 
+              std::vector<L1_candidateLocus_t> l1Mappings;
+              l1Mappings.reserve(64);              
+
               for (int i = 0; i < fragmentCount; i++)
-              //for (int i = 0; i < 5; i++)
               {
                 //Record each fragment's length coverage in genome for supporting visualization
                 if(param.visualize)
@@ -182,7 +184,7 @@ namespace skch
                 l2Mappings.clear();
 
                 //Map this sequence
-                mapSingleQuerySeq(Q, l2Mappings, outstrm);
+                mapSingleQuerySeq(Q, l1Mappings, l2Mappings, outstrm);
 
                 //Write mapping results to file
                 reportL2Mappings(l2Mappings, outstrm);
@@ -206,17 +208,18 @@ namespace skch
        * @param[out]  l2Mappings  Mappings computed after L2 stage
        */
       template<typename Q_Info>
-        inline void mapSingleQuerySeq(Q_Info &Q, MappingResultsVector_t &l2Mappings, std::ofstream &outstrm)
+        inline void mapSingleQuerySeq(Q_Info &Q,
+                                      std::vector<L1_candidateLocus_t> &l1Mappings,
+                                      MappingResultsVector_t &l2Mappings,
+                                      std::ofstream &outstrm)
         {
 #if ENABLE_TIME_PROFILE_L1_L2
           auto t0 = skch::Time::now();
-#endif
-
-#if ENABLE_TIME_PROFILE_L1_L2
           auto t1 = skch::Time::now();
 #endif
-          //L1 Mapping
-          std::vector<L1_candidateLocus_t> l1Mappings; 
+
+          //L1 Mapping (reuse buffer)
+          l1Mappings.clear();
           doL1Mapping(Q, l1Mappings);
 
 #if ENABLE_TIME_PROFILE_L1_L2
@@ -234,8 +237,8 @@ namespace skch
             int countL1Candidates = l1Mappings.size();
 
             std::cerr << Q.kseq->name.s << " " << Q.kseq->seq.l
-              << " " << countL1Candidates 
-              << " " << timeSpentL1.count() 
+              << " " << countL1Candidates
+              << " " << timeSpentL1.count()
               << " " << timeSpentL2.count()
               << " " << timeSpentMappingRead.count()
               << "\n";

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -154,6 +154,10 @@ namespace skch
           std::cerr << "INFO, skch::Map::mapQuery, Fragments " << fragmentCount << std::endl;
 #endif
 
+              //Output vector for L2 mappings (reused across fragments)
+              MappingResultsVector_t l2Mappings;
+              l2Mappings.reserve(8);
+
               for (int i = 0; i < fragmentCount; i++)
               //for (int i = 0; i < 5; i++)
               {
@@ -173,9 +177,9 @@ namespace skch
                 Q.kseq->seq.s = seq->seq.s + i * param.minReadLength;
                 Q.kseq->seq.l = param.minReadLength;
                 Q.seqCounter = seqCounter + i;
-
-                //Output vector for L2 mappings
-                MappingResultsVector_t l2Mappings;
+                
+                //Reuse output vector for L2 mappings (capacity retained)
+                l2Mappings.clear();
 
                 //Map this sequence
                 mapSingleQuerySeq(Q, l2Mappings, outstrm);
@@ -254,9 +258,13 @@ namespace skch
         {
           //Vector of positions of all the hits 
           std::vector<MinimizerMetaData> seedHitsL1;
+          seedHitsL1.reserve(20000);
+
+          // PERF: reuse query minimizer buffer across fragments (capacity retained)
+          Q.minimizerTableQuery.clear();
+          Q.minimizerTableQuery.reserve(4096);
 
           ///1. Compute the minimizers
-
           CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.kseq, param.kmerSize, param.windowSize, param.alphabetSize);
 
 #ifdef DEBUG
@@ -277,8 +285,6 @@ namespace skch
           //Ignore the query in this case
           if(Q.sketchSize == 0)
             return;
-
-          int totalMinimizersPicked = 0;
 
           for(auto it = Q.minimizerTableQuery.begin(); it != uniqEndIter; it++)
           {
@@ -323,31 +329,38 @@ namespace skch
           {
             if(std::distance(it, seedHitsL1.end()) >= minimumHits)
             {
-              auto it2 = it + minimumHits -1;
-              //[it .. it2] are 'minimumHits' consecutive hits 
+              auto it2 = it + minimumHits - 1;
+              //[it .. it2] are 'minimumHits' consecutive hits
 
               //Check if consecutive hits are close enough
-              //NOTE: hits may span more than a read length for a valid match, as we keep window positions 
+              //NOTE: hits may span more than a read length for a valid match, as we keep window positions
               //      for each minimizer
               if(it2->seqId == it->seqId && it2->wpos - it->wpos < Q.kseq->seq.l)
               {
                 //Save <1st pos --- 2nd pos>
-                L1_candidateLocus_t candidate{it->seqId, 
+                L1_candidateLocus_t candidate{it->seqId,
                     std::max(0, it2->wpos - offset_t(Q.kseq->seq.l) + 1), it->wpos};
 
                 //Check if this candidate overlaps with last inserted one
-                auto lst = l1Mappings.end(); lst--;
-
-                //match seq_no and see if this candidate begins before last element ends
-                if( l1Mappings.size() > 0 
-                    && candidate.seqId == lst->seqId 
-                    && lst->rangeEndPos >= candidate.rangeStartPos)
+                if(!l1Mappings.empty())
                 {
-                  //Push the end pos of last candidate locus further out
-                  lst->rangeEndPos = std::max(candidate.rangeEndPos, lst->rangeEndPos);
+                  auto &lst = l1Mappings.back();
+
+                  //match seq_no and see if this candidate begins before last element ends
+                  if(candidate.seqId == lst.seqId && lst.rangeEndPos >= candidate.rangeStartPos)
+                  {
+                    //Push the end pos of last candidate locus further out
+                    lst.rangeEndPos = std::max(candidate.rangeEndPos, lst.rangeEndPos);
+                  }
+                  else
+                  {
+                    l1Mappings.push_back(candidate);
+                  }
                 }
                 else
+                {
                   l1Mappings.push_back(candidate);
+                }
               }
             }
           }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -264,13 +264,13 @@ namespace skch
       template <typename Q_Info, typename Vec>
         void doL1Mapping(Q_Info &Q, Vec &l1Mappings)
         {
-          //Vector of positions of all the hits 
+          //Vector of positions of all the hits
           std::vector<MinimizerMetaData> seedHitsL1;
-          seedHitsL1.reserve(20000);
 
-          // PERF: reuse query minimizer buffer across fragments (capacity retained)
+          // Reuse query minimizer buffer across fragments (capacity retained)
           Q.minimizerTableQuery.clear();
-          Q.minimizerTableQuery.reserve(4096);
+          if(Q.minimizerTableQuery.capacity() < 4096)
+            Q.minimizerTableQuery.reserve(4096);
 
           ///1. Compute the minimizers
           CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.kseq, param.kmerSize, param.windowSize, param.alphabetSize);
@@ -288,27 +288,31 @@ namespace skch
 
           //This is the sketch size for estimating jaccard
           Q.sketchSize = std::distance(Q.minimizerTableQuery.begin(), uniqEndIter);
-
+          
           //For invalid query (example : just NNNs), we may be left with 0 sketch size
           //Ignore the query in this case
           if(Q.sketchSize == 0)
             return;
+          
+          // Reserve seed-hit storage based on the actual number of unique minimizers
+          const size_t uniqCount = static_cast<size_t>(Q.sketchSize);
+          if(seedHitsL1.capacity() < uniqCount * 8)
+            seedHitsL1.reserve(uniqCount * 8);
 
-          for(auto it = Q.minimizerTableQuery.begin(); it != uniqEndIter; it++)
+          for(auto it = Q.minimizerTableQuery.begin(); it != uniqEndIter; ++it)
           {
             //Check if hash value exists in the reference lookup index
             auto seedFind = refSketch.minimizerPosLookupIndex.find(it->hash);
-
+          
             if(seedFind != refSketch.minimizerPosLookupIndex.end())
             {
               const auto& hitPositionList = seedFind->second;
-
+          
               //Save the positions (Ignore high frequency hits)
               if(hitPositionList.size() < refSketch.getFreqThreshold())
               {
                 seedHitsL1.insert(seedHitsL1.end(), hitPositionList.begin(), hitPositionList.end());
               }
-
             }
           }
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -154,17 +154,12 @@ namespace skch
           std::cerr << "INFO, skch::Map::mapQuery, Fragments " << fragmentCount << std::endl;
 #endif
 
-              std::vector<L1_candidateLocus_t> l1Mappings;
-              l1Mappings.reserve(64);
-
-              //Reusable buffers across fragments
+              //Output vector for L2 mappings (reused across fragments)
               MappingResultsVector_t l2Mappings;
               l2Mappings.reserve(8);
 
-              // PERF: reuse QueryMetaData and kseq copy buffer across fragments
-              QueryMetaData <decltype(seq), MinVec_Type> Q;
-              kseq_t seqCopy = *seq;
-              Q.kseq = &seqCopy;
+              std::vector<L1_candidateLocus_t> l1Mappings;
+              l1Mappings.reserve(64);              
 
               for (int i = 0; i < fragmentCount; i++)
               {
@@ -177,13 +172,14 @@ namespace skch
                     metadata.push_back( ContigInfo{seq->name.s, param.minReadLength + (len % param.minReadLength)} );
                 }
 
-                // Update per-fragment view into the same underlying sequence buffer
-                Q.kseq->name = seq->name; // keep same contig name
+                QueryMetaData <decltype(seq), MinVec_Type> Q;
+                auto seqCopy = *seq;
+
+                Q.kseq = &seqCopy;
                 Q.kseq->seq.s = seq->seq.s + i * param.minReadLength;
                 Q.kseq->seq.l = param.minReadLength;
-
                 Q.seqCounter = seqCounter + i;
-
+                
                 //Reuse output vector for L2 mappings (capacity retained)
                 l2Mappings.clear();
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -287,7 +287,7 @@ namespace skch
 
             if(seedFind != refSketch.minimizerPosLookupIndex.end())
             {
-              auto hitPositionList = seedFind->second;
+              const auto& hitPositionList = seedFind->second;
 
               //Save the positions (Ignore high frequency hits)
               if(hitPositionList.size() < refSketch.getFreqThreshold())

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -120,6 +120,7 @@ namespace skch
         {
           //Open the file using kseq
           gzFile fp = gzopen(queryFileName.c_str(), "r");
+          gzbuffer(fp, 1 << 20);
           kseq_t *seq = kseq_init(fp);
 
 #ifdef DEBUG

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -154,12 +154,17 @@ namespace skch
           std::cerr << "INFO, skch::Map::mapQuery, Fragments " << fragmentCount << std::endl;
 #endif
 
-              //Output vector for L2 mappings (reused across fragments)
+              std::vector<L1_candidateLocus_t> l1Mappings;
+              l1Mappings.reserve(64);
+
+              //Reusable buffers across fragments
               MappingResultsVector_t l2Mappings;
               l2Mappings.reserve(8);
 
-              std::vector<L1_candidateLocus_t> l1Mappings;
-              l1Mappings.reserve(64);              
+              // PERF: reuse QueryMetaData and kseq copy buffer across fragments
+              QueryMetaData <decltype(seq), MinVec_Type> Q;
+              kseq_t seqCopy = *seq;
+              Q.kseq = &seqCopy;
 
               for (int i = 0; i < fragmentCount; i++)
               {
@@ -172,14 +177,13 @@ namespace skch
                     metadata.push_back( ContigInfo{seq->name.s, param.minReadLength + (len % param.minReadLength)} );
                 }
 
-                QueryMetaData <decltype(seq), MinVec_Type> Q;
-                auto seqCopy = *seq;
-
-                Q.kseq = &seqCopy;
+                // Update per-fragment view into the same underlying sequence buffer
+                Q.kseq->name = seq->name; // keep same contig name
                 Q.kseq->seq.s = seq->seq.s + i * param.minReadLength;
                 Q.kseq->seq.l = param.minReadLength;
+
                 Q.seqCounter = seqCounter + i;
-                
+
                 //Reuse output vector for L2 mappings (capacity retained)
                 l2Mappings.clear();
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -41,6 +41,7 @@ namespace skch
     bool visualize;                                   //Visualize the conserved regions of two genomes
     bool matrixOutput;                                //report fastani results as lower triangular matrix
     bool extendedMetrics = false;                     //report extra fragment-level ANI metrics
+    bool header = false;                              //write a header row in tabular output
     float maxRatioDiff;                               //max Ratio for sanity check
     bool sanityCheck;                                 // Sanity check for extreme Cases
   };

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -40,6 +40,7 @@ namespace skch
     bool reportAll;                                   //Report all alignments if this is true
     bool visualize;                                   //Visualize the conserved regions of two genomes
     bool matrixOutput;                                //report fastani results as lower triangular matrix
+    bool extendedMetrics = false;                     //report extra fragment-level ANI metrics
     float maxRatioDiff;                               //max Ratio for sanity check
     bool sanityCheck;                                 // Sanity check for extreme Cases
   };

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -33,6 +33,10 @@ namespace skch
     std::vector<std::string> refSequences;            //reference sequence(s)
     std::vector<std::string> querySequences;          //query sequence(s)
     std::string outFileName;                          //output file name
+    std::string writeRefSketchFile = "";
+    bool writeRefSketchMode = false;
+    std::string sketchFile;
+    bool loadSketchMode;
     bool reportAll;                                   //Report all alignments if this is true
     bool visualize;                                   //Visualize the conserved regions of two genomes
     bool matrixOutput;                                //report fastani results as lower triangular matrix

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -222,7 +222,7 @@ namespace skch
       .doc_column(5)
       .last_column(80);
 
-    std::string description = "fastANI is a fast alignment-free implementation for computing whole-genome Average Nucleotide Identity (ANI) between genomes\n-----------------\nExample usage:\n1 vs 1 comparison with extended metrics:\n$ fastANI -q query.fa -r reference.fa --extended-metrics -o output.txt\n\nGenerate a reference sketch from a reference list:\n$ fastANI --refList references.txt --write-ref-sketch reference_sketch\n\n1 vs all comparison using a sketch with visualization output:\n$ fastANI -q query.fa --sketch reference_sketch --visualize -o output.txt\n\nBasic all vs all comparison with query list, reference list, and matrix output:\n$ fastANI --queryList queries.txt --refList references.txt --matrix -o output.txt";
+    std::string description = "\nfastANI is a fast alignment-free implementation for computing whole-genome Average Nucleotide Identity (ANI) between genomes\n\nEXAMPLE USAGE\n-------------\n1 vs 1 comparison with extended metrics:\n$ fastANI -q query.fa -r reference.fa --extended-metrics -o output.txt\n\nGenerate a reference sketch from a reference list:\n$ fastANI --refList references.txt --write-ref-sketch reference_sketch\n\n1 vs all comparison using a sketch with visualization output:\n$ fastANI -q query.fa --sketch reference_sketch --visualize -o output.txt\n\nBasic all vs all comparison with query list, reference list, and matrix output:\n$ fastANI --queryList queries.txt --refList references.txt --matrix -o output.txt";
 
     auto printHelp = [&]() {
       auto man = clipp::man_page{}
@@ -231,7 +231,7 @@ namespace skch
         .append_section("OUTPUT OPTIONS\n--------------", clipp::documentation(output_cli, fmt).str())
         .append_section("MAPPING PARAMETERS\n------------------", clipp::documentation(mapping_cli, fmt).str())
         .append_section("EXECUTION OPTIONS\n-----------------", clipp::documentation(execution_cli, fmt).str())
-        .prepend_section("-----------------", description);
+        .prepend_section("", description);
 
       clipp::operator<<(std::cout, man) << std::endl;
     };

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -4,7 +4,7 @@
  * @author  Chirag Jain <cjain7@gatech.edu>
  */
 
-#ifndef PARSE_CMD_HPP 
+#ifndef PARSE_CMD_HPP
 #define PARSE_CMD_HPP
 
 #include <iostream>
@@ -25,31 +25,31 @@ namespace skch
 
   /**
    * @brief                   Parse the file which has list of reference or query files
-   * @param[in]   fileToRead  File containing list of ref/query files 
-   * @param[out]  fileList    List of files will be saved in this vector   
+   * @param[in]   fileToRead  File containing list of ref/query files
+   * @param[out]  fileList    List of files will be saved in this vector
    */
   template <typename VEC>
-    void parseFileList(std::string &fileToRead, VEC &fileList)
+  void parseFileList(std::string &fileToRead, VEC &fileList)
+  {
+    std::string line;
+
+    std::ifstream in(fileToRead);
+
+    if (in.fail())
     {
-      std::string line;
-
-      std::ifstream in(fileToRead);
-
-      if (in.fail())
-      {
-        std::cerr << "ERROR, skch::parseFileList, Could not open " << fileToRead << "\n";
-        exit(1);
-      }
-
-      while (std::getline(in, line))
-      {
-        //trim whitespaces
-        skch::CommonFunc::trim (line);
-
-        if (line.length() > 0)        //avoid empty strings
-          fileList.push_back(line);
-      }
+      std::cerr << "ERROR, skch::parseFileList, Could not open " << fileToRead << "\n";
+      exit(1);
     }
+
+    while (std::getline(in, line))
+    {
+      //trim whitespaces
+      skch::CommonFunc::trim(line);
+
+      if (line.length() > 0)        //avoid empty strings
+        fileList.push_back(line);
+    }
+  }
 
   /**
    * @brief                     validate the reference and query file(s)
@@ -57,37 +57,37 @@ namespace skch
    * @param[in] refSequences    vector containing reference file names
    */
   template <typename VEC>
-    void validateInputFiles(VEC &querySequences, VEC &refSequences)
+  void validateInputFiles(VEC &querySequences, VEC &refSequences)
+  {
+    if (refSequences.size() == 0)
     {
-      if (querySequences.size() == 0 || refSequences.size() == 0)
+      std::cerr << "ERROR, skch::validateInputFiles, Count of ref genomes should be non-zero" << std::endl;
+      exit(1);
+    }
+
+    //Open file one by one
+    for(auto &e : querySequences)
+    {
+      std::ifstream in(e);
+
+      if (in.fail())
       {
-        std::cerr << "ERROR, skch::validateInputFiles, Count of query and ref genomes should be non-zero" << std::endl;
+        std::cerr << "ERROR, skch::validateInputFiles, Could not open " << e << std::endl;
         exit(1);
       }
+    }
 
-      //Open file one by one
-      for(auto &e : querySequences)
+    for(auto &e : refSequences)
+    {
+      std::ifstream in(e);
+
+      if (in.fail())
       {
-        std::ifstream in(e);
-
-        if (in.fail())
-        {
-          std::cerr << "ERROR, skch::validateInputFiles, Could not open " << e << std::endl;
-          exit(1);
-        }
-      }
-
-      for(auto &e : refSequences)
-      {
-        std::ifstream in(e);
-
-        if (in.fail())
-        {
-          std::cerr << "ERROR, skch::validateInputFiles, Could not open " << e << std::endl;
-          exit(1);
-        }
+        std::cerr << "ERROR, skch::validateInputFiles, Could not open " << e << std::endl;
+        exit(1);
       }
     }
+  }
 
   /**
    * @brief                   Print the parsed cmd line options
@@ -111,7 +111,7 @@ namespace skch
    * @param[in]   cmd
    * @param[out]  parameters  sketch parameters are saved here
    */
-  void parseandSave(int argc, char** argv, 
+  void parseandSave(int argc, char** argv,
       skch::Parameters &parameters)
   {
     //defaults
@@ -128,7 +128,10 @@ namespace skch
     parameters.maxRatioDiff = 100.0;
     parameters.reportAll = true; //we need all mappings per fragment, not just best 1% as in mashmap
     parameters.sanityCheck = false;
-
+    parameters.writeRefSketchFile = "";
+    parameters.writeRefSketchMode = false;
+    parameters.sketchFile = "";
+    parameters.loadSketchMode = false;
 
     std::string refName, refList;
     std::string qryName, qryList;
@@ -150,12 +153,20 @@ namespace skch
     auto output_cmd = (clipp::option("-o", "--output") & clipp::value("value", parameters.outFileName)) % "output file name";
     auto sanitycheck_cmd = clipp::option("-s", "--sanityCheck").set(parameters.sanityCheck).doc("run sanity check");
     auto version_cmd = clipp::option("-v", "--version").set(versioncheck).doc("show version");
+    auto sketch_cmd =
+      (clipp::option("--sketch") & clipp::value("value", parameters.sketchFile))
+      % "load reference sketches from file prefix instead of rebuilding";
+    auto write_ref_sketch_cmd =
+      (clipp::option("--write-ref-sketch") & clipp::value("value", parameters.writeRefSketchFile))
+      % "write reference sketches to file and exit";
 
     auto cli =
       (
        help_cmd,
        ref_cmd,
        refList_cmd,
+       write_ref_sketch_cmd,
+       sketch_cmd,
        qry_cmd,
        qryList_cmd,
        kmer_cmd,
@@ -172,7 +183,7 @@ namespace skch
 
     //with formatting options
     auto fmt = clipp::doc_formatting{}
-    .first_column(0)
+      .first_column(0)
       .doc_column(5)
       .last_column(80);
 
@@ -197,27 +208,41 @@ namespace skch
       exit(0);
     }
 
-    if (refName == "" && refList == "")
+    if(!parameters.writeRefSketchFile.empty())
+    {
+      parameters.writeRefSketchMode = true;
+    }
+
+    if(!parameters.sketchFile.empty())
+      parameters.loadSketchMode = true;
+
+    if (!parameters.loadSketchMode && refName == "" && refList == "")
     {
       std::cerr << "Provide reference file (s)\n";
       exit(1);
     }
 
-    if (qryName == "" && qryList == "")
+    if (!parameters.writeRefSketchMode && qryName == "" && qryList == "")
     {
       std::cerr << "Provide query file (s)\n";
       exit(1);
     }
 
-    if (refName != "")
-      parameters.refSequences.push_back(refName);
-    else
-      parseFileList(refList, parameters.refSequences);
+    if (!parameters.loadSketchMode)
+    {
+      if (refName != "")
+        parameters.refSequences.push_back(refName);
+      else
+        parseFileList(refList, parameters.refSequences);
+    }
 
-    if (qryName != "")
-      parameters.querySequences.push_back(qryName);
-    else
-      parseFileList(qryList, parameters.querySequences);
+    if (!parameters.writeRefSketchMode)
+    {
+      if (qryName != "")
+        parameters.querySequences.push_back(qryName);
+      else
+        parseFileList(qryList, parameters.querySequences);
+    }
 
     assert(parameters.minFraction >= 0.0 && parameters.minFraction <= 1.0);
 
@@ -227,12 +252,30 @@ namespace skch
         parameters.percentageIdentity,
         parameters.minReadLength, parameters.referenceSize);
 
-    printCmdOptions(parameters);
+    if(parameters.writeRefSketchMode)
+    {
+      std::vector<std::string> emptyQueries;
+      validateInputFiles(emptyQueries, parameters.refSequences);
+    }
+    else if(parameters.loadSketchMode)
+    {
+      for(auto &e : parameters.querySequences)
+      {
+        std::ifstream in(e);
+        if(in.fail())
+        {
+          std::cerr << "ERROR, skch::validateInputFiles, Could not open " << e << std::endl;
+          exit(1);
+        }
+      }
+    }
+    else
+    {
+      validateInputFiles(parameters.querySequences, parameters.refSequences);
+    }
 
-    //Check if files are valid
-    validateInputFiles(parameters.querySequences, parameters.refSequences);
+    printCmdOptions(parameters);
   }
 }
-
 
 #endif

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -159,6 +159,9 @@ namespace skch
     auto write_ref_sketch_cmd =
       (clipp::option("--write-ref-sketch") & clipp::value("value", parameters.writeRefSketchFile))
       % "write reference sketches to file and exit";
+    auto extended_metrics_cmd =
+      clipp::option("--extended-metrics").set(parameters.extendedMetrics)
+      .doc("report extended fragment-level ANI metrics");
 
     auto cli =
       (
@@ -176,6 +179,7 @@ namespace skch
        maxratio_cmd,
        visualize_cmd,
        matrix_cmd,
+       extended_metrics_cmd,
        output_cmd,
        sanitycheck_cmd,
        version_cmd

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -138,27 +138,22 @@ namespace skch
     bool versioncheck = false;
     bool help = false;
 
-    auto help_cmd = clipp::option("-h", "--help").set(help).doc("print this help page");
+    // INPUT OPTIONS
     auto ref_cmd = (clipp::option("-r", "--ref") & clipp::value("value", refName)) % "reference genome (fasta/fastq)[.gz]";
     auto refList_cmd = (clipp::option("--rl", "--refList") & clipp::value("value", refList)) % "a file containing list of reference genome files, one genome per line";
     auto qry_cmd = (clipp::option("-q", "--query") & clipp::value("value", qryName)) % "query genome (fasta/fastq)[.gz]";
     auto qryList_cmd = (clipp::option("--ql", "--queryList") & clipp::value("value", qryList)) % "a file containing list of query genome files, one genome per line";
-    auto kmer_cmd = (clipp::option("-k", "--kmer") & clipp::value("value", parameters.kmerSize)) % "kmer size <= 16 [default : 16]";
-    auto thread_cmd = (clipp::option("-t", "--threads") & clipp::value("value", parameters.threads)) % "thread count for parallel execution [default : 1]";
-    auto fraglen_cmd = (clipp::option("--fragLen") & clipp::value("value", parameters.minReadLength)) % "fragment length [default : 3,000]";
-    auto minfraction_cmd = (clipp::option("--minFraction") & clipp::value("value", parameters.minFraction)) % "minimum fraction of genome that must be shared for trusting ANI. If reference and query genome size differ, smaller one among the two is considered. [default : 0.2]";
-    auto maxratio_cmd = (clipp::option("--maxRatioDiff") & clipp::value("value", parameters.maxRatioDiff)) % "maximum difference between (Total Ref. Length/Total Occ. Hashes) and (Total Ref. Length/Total No. Hashes). [default : 10.0]";
-    auto visualize_cmd = clipp::option("--visualize").set(parameters.visualize).doc("output mappings for visualization, can be enabled for single genome to single genome comparison only [disabled by default]");
-    auto matrix_cmd = clipp::option("--matrix").set(parameters.matrixOutput).doc("also output ANI values as lower triangular matrix (format inspired from phylip). If enabled, you should expect an output file with .matrix extension [disabled by default]");
-    auto output_cmd = (clipp::option("-o", "--output") & clipp::value("value", parameters.outFileName)) % "output file name";
-    auto sanitycheck_cmd = clipp::option("-s", "--sanityCheck").set(parameters.sanityCheck).doc("run sanity check");
-    auto version_cmd = clipp::option("-v", "--version").set(versioncheck).doc("show version");
     auto sketch_cmd =
       (clipp::option("--sketch") & clipp::value("value", parameters.sketchFile))
       % "load reference sketches from file prefix instead of rebuilding";
+
+    // OUTPUT OPTIONS
+    auto output_cmd = (clipp::option("-o", "--output") & clipp::value("value", parameters.outFileName)) % "output file name";
     auto write_ref_sketch_cmd =
       (clipp::option("--write-ref-sketch") & clipp::value("value", parameters.writeRefSketchFile))
       % "write reference sketches to file and exit";
+    auto matrix_cmd = clipp::option("--matrix").set(parameters.matrixOutput).doc("also output ANI values as lower triangular matrix (format inspired from phylip). If enabled, you should expect an output file with .matrix extension [disabled by default]");
+    auto visualize_cmd = clipp::option("--visualize").set(parameters.visualize).doc("output mappings for visualization, can be enabled for single genome to single genome comparison only [disabled by default]");
     auto extended_metrics_cmd =
       clipp::option("--extended-metrics").set(parameters.extendedMetrics)
       .doc("report extended fragment-level ANI metrics");
@@ -166,27 +161,59 @@ namespace skch
       clipp::option("--header").set(parameters.header)
       .doc("write a header row in tab-delimited output");
 
-    auto cli =
+    // MAPPING PARAMETERS
+    auto kmer_cmd = (clipp::option("-k", "--kmer") & clipp::value("value", parameters.kmerSize)) % "kmer size <= 16 [default : 16]";
+    auto fraglen_cmd = (clipp::option("--fragLen") & clipp::value("value", parameters.minReadLength)) % "fragment length [default : 3,000]";
+    auto minfraction_cmd = (clipp::option("--minFraction") & clipp::value("value", parameters.minFraction)) % "minimum fraction of genome that must be shared for trusting ANI. If reference and query genome size differ, smaller one among the two is considered. [default : 0.2]";
+    auto maxratio_cmd = (clipp::option("--maxRatioDiff") & clipp::value("value", parameters.maxRatioDiff)) % "maximum difference between (Total Ref. Length/Total Occ. Hashes) and (Total Ref. Length/Total No. Hashes). [default : 10.0]";
+
+    // EXECUTION OPTIONS
+    auto thread_cmd = (clipp::option("-t", "--threads") & clipp::value("value", parameters.threads)) % "thread count for parallel execution [default : 1]";
+    auto sanitycheck_cmd = clipp::option("-s", "--sanityCheck").set(parameters.sanityCheck).doc("run sanity check");
+    auto help_cmd = clipp::option("-h", "--help").set(help).doc("print this help page");
+    auto version_cmd = clipp::option("-v", "--version").set(versioncheck).doc("show version");
+
+    auto input_cli =
       (
-       help_cmd,
        ref_cmd,
        refList_cmd,
-       write_ref_sketch_cmd,
-       sketch_cmd,
        qry_cmd,
        qryList_cmd,
+       sketch_cmd
+      );
+
+    auto output_cli =
+      (
+       output_cmd,
+       write_ref_sketch_cmd,
+       matrix_cmd,
+       visualize_cmd,
+       extended_metrics_cmd,
+       header_cmd
+      );
+
+    auto mapping_cli =
+      (
        kmer_cmd,
-       thread_cmd,
        fraglen_cmd,
        minfraction_cmd,
-       maxratio_cmd,
-       visualize_cmd,
-       matrix_cmd,
-       extended_metrics_cmd,
-       header_cmd,
-       output_cmd,
+       maxratio_cmd
+      );
+
+    auto execution_cli =
+      (
+       thread_cmd,
        sanitycheck_cmd,
+       help_cmd,
        version_cmd
+      );
+
+    auto cli =
+      (
+       input_cli,
+       output_cli,
+       mapping_cli,
+       execution_cli
       );
 
     //with formatting options
@@ -195,18 +222,30 @@ namespace skch
       .doc_column(5)
       .last_column(80);
 
-    std::string description = "fastANI is a fast alignment-free implementation for computing whole-genome Average Nucleotide Identity (ANI) between genomes\n-----------------\nExample usage:\n$ fastANI -q genome1.fa -r genome2.fa -o output.txt\n$ fastANI -q genome1.fa --rl genome_list.txt -o output.txt";
+    std::string description = "fastANI is a fast alignment-free implementation for computing whole-genome Average Nucleotide Identity (ANI) between genomes\n-----------------\nExample usage:\n1 vs 1 comparison with extended metrics:\n$ fastANI -q query.fa -r reference.fa --extended-metrics -o output.txt\n\nGenerate a reference sketch from a reference list:\n$ fastANI --refList references.txt --write-ref-sketch reference_sketch\n\n1 vs all comparison using a sketch with visualization output:\n$ fastANI -q query.fa --sketch reference_sketch --visualize -o output.txt\n\nBasic all vs all comparison with query list, reference list, and matrix output:\n$ fastANI --queryList queries.txt --refList references.txt --matrix -o output.txt";
+
+    auto printHelp = [&]() {
+      auto man = clipp::man_page{}
+        .append_section("SYNOPSIS\n--------", clipp::usage_lines(cli, argv[0], fmt).str())
+        .append_section("INPUT OPTIONS\n-------------", clipp::documentation(input_cli, fmt).str())
+        .append_section("OUTPUT OPTIONS\n--------------", clipp::documentation(output_cli, fmt).str())
+        .append_section("MAPPING PARAMETERS\n------------------", clipp::documentation(mapping_cli, fmt).str())
+        .append_section("EXECUTION OPTIONS\n-----------------", clipp::documentation(execution_cli, fmt).str())
+        .prepend_section("-----------------", description);
+
+      clipp::operator<<(std::cout, man) << std::endl;
+    };
 
     if(!clipp::parse(argc, argv, cli))
     {
       //print help page
-      clipp::operator<<(std::cout, clipp::make_man_page(cli, argv[0], fmt).prepend_section("-----------------", description)) << std::endl;
+      printHelp();
       exit(1);
     }
 
     if (help)
     {
-      clipp::operator<<(std::cout, clipp::make_man_page(cli, argv[0], fmt).prepend_section("-----------------", description)) << std::endl;
+      printHelp();
       exit(0);
     }
 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -162,6 +162,9 @@ namespace skch
     auto extended_metrics_cmd =
       clipp::option("--extended-metrics").set(parameters.extendedMetrics)
       .doc("report extended fragment-level ANI metrics");
+    auto header_cmd =
+      clipp::option("--header").set(parameters.header)
+      .doc("write a header row in tab-delimited output");
 
     auto cli =
       (
@@ -180,6 +183,7 @@ namespace skch
        visualize_cmd,
        matrix_cmd,
        extended_metrics_cmd,
+       header_cmd,
        output_cmd,
        sanitycheck_cmd,
        version_cmd

--- a/src/map/include/sketch_io.hpp
+++ b/src/map/include/sketch_io.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <cstdint>
+
+#include "map/include/winSketch.hpp"
+#include "map/include/map_parameters.hpp"
+
+namespace skch
+{
+  inline void saveReferenceSketch(const Sketch& sketch,
+                                  const Parameters& parameters,
+                                  const std::string& outFile)
+  {
+    std::ofstream out(outFile, std::ios::binary);
+    if(!out)
+      throw std::runtime_error("ERROR: cannot open sketch output file");
+
+    uint32_t version = 1;
+    out.write(reinterpret_cast<const char*>(&version), sizeof(version));
+    out.write(reinterpret_cast<const char*>(&parameters.kmerSize), sizeof(parameters.kmerSize));
+    out.write(reinterpret_cast<const char*>(&parameters.windowSize), sizeof(parameters.windowSize));
+
+    // metadata
+    size_t nMetadata = sketch.metadata.size();
+    out.write(reinterpret_cast<const char*>(&nMetadata), sizeof(nMetadata));
+    for(const auto& c : sketch.metadata)
+    {
+      size_t nameLen = c.name.size();
+      out.write(reinterpret_cast<const char*>(&nameLen), sizeof(nameLen));
+      out.write(c.name.data(), nameLen);
+      out.write(reinterpret_cast<const char*>(&c.len), sizeof(c.len));
+    }
+
+    // sequencesByFileInfo
+    size_t nSeqByFile = sketch.sequencesByFileInfo.size();
+    out.write(reinterpret_cast<const char*>(&nSeqByFile), sizeof(nSeqByFile));
+    if(nSeqByFile > 0)
+    {
+      out.write(reinterpret_cast<const char*>(sketch.sequencesByFileInfo.data()),
+                nSeqByFile * sizeof(sketch.sequencesByFileInfo[0]));
+    }
+
+    // minimizerIndex
+    size_t nMinIdx = sketch.minimizerIndex.size();
+    out.write(reinterpret_cast<const char*>(&nMinIdx), sizeof(nMinIdx));
+    if(nMinIdx > 0)
+    {
+      out.write(reinterpret_cast<const char*>(sketch.minimizerIndex.data()),
+                nMinIdx * sizeof(sketch.minimizerIndex[0]));
+    }
+
+    // minimizerPosLookupIndex
+    size_t nKeys = sketch.minimizerPosLookupIndex.size();
+    out.write(reinterpret_cast<const char*>(&nKeys), sizeof(nKeys));
+
+    for(const auto& kv : sketch.minimizerPosLookupIndex)
+    {
+      const MinimizerMapKeyType& key = kv.first;
+      const MinimizerMapValueType& vals = kv.second;
+
+      out.write(reinterpret_cast<const char*>(&key), sizeof(key));
+
+      size_t nVals = vals.size();
+      out.write(reinterpret_cast<const char*>(&nVals), sizeof(nVals));
+
+      if(nVals > 0)
+      {
+        out.write(reinterpret_cast<const char*>(vals.data()),
+                  nVals * sizeof(vals[0]));
+      }
+    }
+
+    out.close();
+  }
+
+  inline Sketch loadReferenceSketch(const Parameters& parameters,
+                                    const std::string& inFile)
+  {
+    std::ifstream in(inFile, std::ios::binary);
+    if(!in)
+      throw std::runtime_error("ERROR: cannot open sketch input file");
+
+    Sketch sketch(parameters, true);
+
+    uint32_t version = 0;
+    in.read(reinterpret_cast<char*>(&version), sizeof(version));
+    if(version != 1)
+      throw std::runtime_error("ERROR: unsupported sketch version");
+
+    int savedKmer = 0;
+    int savedWindow = 0;
+    in.read(reinterpret_cast<char*>(&savedKmer), sizeof(savedKmer));
+    in.read(reinterpret_cast<char*>(&savedWindow), sizeof(savedWindow));
+
+    if(savedKmer != parameters.kmerSize)
+      throw std::runtime_error("ERROR: sketch kmerSize does not match current run");
+
+    if(savedWindow != parameters.windowSize)
+      throw std::runtime_error("ERROR: sketch windowSize does not match current run");
+
+    // metadata
+    size_t nMetadata = 0;
+    in.read(reinterpret_cast<char*>(&nMetadata), sizeof(nMetadata));
+    sketch.metadata.resize(nMetadata);
+
+    for(size_t i = 0; i < nMetadata; i++)
+    {
+      size_t nameLen = 0;
+      in.read(reinterpret_cast<char*>(&nameLen), sizeof(nameLen));
+
+      sketch.metadata[i].name.resize(nameLen);
+      in.read(&sketch.metadata[i].name[0], nameLen);
+
+      in.read(reinterpret_cast<char*>(&sketch.metadata[i].len), sizeof(sketch.metadata[i].len));
+    }
+
+    // sequencesByFileInfo
+    size_t nSeqByFile = 0;
+    in.read(reinterpret_cast<char*>(&nSeqByFile), sizeof(nSeqByFile));
+    sketch.sequencesByFileInfo.resize(nSeqByFile);
+    if(nSeqByFile > 0)
+    {
+      in.read(reinterpret_cast<char*>(sketch.sequencesByFileInfo.data()),
+              nSeqByFile * sizeof(sketch.sequencesByFileInfo[0]));
+    }
+
+    // minimizerIndex
+    size_t nMinIdx = 0;
+    in.read(reinterpret_cast<char*>(&nMinIdx), sizeof(nMinIdx));
+    sketch.minimizerIndex.resize(nMinIdx);
+    if(nMinIdx > 0)
+    {
+      in.read(reinterpret_cast<char*>(sketch.minimizerIndex.data()),
+              nMinIdx * sizeof(sketch.minimizerIndex[0]));
+    }
+
+    // minimizerPosLookupIndex
+    size_t nKeys = 0;
+    in.read(reinterpret_cast<char*>(&nKeys), sizeof(nKeys));
+
+    for(size_t i = 0; i < nKeys; i++)
+    {
+      MinimizerMapKeyType key;
+      size_t nVals = 0;
+
+      in.read(reinterpret_cast<char*>(&key), sizeof(key));
+      in.read(reinterpret_cast<char*>(&nVals), sizeof(nVals));
+
+      auto& vals = sketch.minimizerPosLookupIndex[key];
+      vals.resize(nVals);
+
+      if(nVals > 0)
+      {
+        in.read(reinterpret_cast<char*>(vals.data()),
+                nVals * sizeof(vals[0]));
+      }
+    }
+
+    if(!in)
+      throw std::runtime_error("ERROR: failed while reading sketch file");
+
+    sketch.computeFreqHist();
+    return sketch;
+  }
+}

--- a/src/map/include/sketch_io.hpp
+++ b/src/map/include/sketch_io.hpp
@@ -141,6 +141,9 @@ namespace skch
     size_t nKeys = 0;
     in.read(reinterpret_cast<char*>(&nKeys), sizeof(nKeys));
 
+    sketch.minimizerPosLookupIndex.clear();
+    sketch.minimizerPosLookupIndex.reserve(nKeys);
+
     for(size_t i = 0; i < nKeys; i++)
     {
       MinimizerMapKeyType key;
@@ -149,7 +152,7 @@ namespace skch
       in.read(reinterpret_cast<char*>(&key), sizeof(key));
       in.read(reinterpret_cast<char*>(&nVals), sizeof(nVals));
 
-      auto& vals = sketch.minimizerPosLookupIndex[key];
+      MinimizerMapValueType vals;
       vals.resize(nVals);
 
       if(nVals > 0)
@@ -157,6 +160,8 @@ namespace skch
         in.read(reinterpret_cast<char*>(vals.data()),
                 nVals * sizeof(vals[0]));
       }
+
+      sketch.minimizerPosLookupIndex.emplace(key, std::move(vals));
     }
 
     if(!in)

--- a/src/map/include/slidingMap.hpp
+++ b/src/map/include/slidingMap.hpp
@@ -139,19 +139,20 @@ namespace skch
           hash_t hashVal = m->hash;
           int status;
 
+          auto it = slidingWindowMinhashes.find(hashVal);
+
           //if hash doesn't exist in the map, add to it
-          if(slidingWindowMinhashes.find(hashVal) == slidingWindowMinhashes.end())
+          if(it == slidingWindowMinhashes.end())
           {
-            slidingWindowMinhashes[hashVal] = slidingMapContainerValueType{this->NAPos, m->wpos};   //add the hash to window
+            it = slidingWindowMinhashes.emplace(hashVal, slidingMapContainerValueType{this->NAPos, m->wpos}).first;
             status = IN::UNIQ;
           }
           else
           {
-            status = (slidingWindowMinhashes[hashVal].wposR == NAPos) ? IN::CPLD 
-              : IN::REV;
+            status = (it->second.wposR == NAPos) ? IN::CPLD : IN::REV;
 
             //if hash already exists in the map, just revise it
-            slidingWindowMinhashes[hashVal].wposR = m->wpos;
+            it->second.wposR = m->wpos;
           }
 
           updateCountersAfterInsert(status, m);
@@ -169,18 +170,17 @@ namespace skch
           hash_t hashVal = m->hash;
           int status;
           bool pivotDeleteCase = false;
-          
-          assert(this->slidingWindowMinhashes.find(hashVal) != this->slidingWindowMinhashes.end());
 
-          //This hashVal may exist with different wpos from 
-          //reference, do nothing in that case
-          
-          if(this->slidingWindowMinhashes[hashVal].wposR == m->wpos)
+          auto it = this->slidingWindowMinhashes.find(hashVal);
+          assert(it != this->slidingWindowMinhashes.end());
+
+          //This hashVal may exist with different wpos from reference, do nothing in that case
+          if(it->second.wposR == m->wpos)
           {
-            if(this->slidingWindowMinhashes[hashVal].wposQ == NAPos)
+            if(it->second.wposQ == NAPos)
             {
               //Handle pivot deletion as a separate case
-              if(this->slidingWindowMinhashes.find(hashVal) == pivot)
+              if(it == pivot)
               {
                 pivot++;
 
@@ -190,13 +190,13 @@ namespace skch
                 pivotDeleteCase = true;
               }
 
-              this->slidingWindowMinhashes.erase(hashVal);              //Remove the entry from the map
-              status = OUT::DEL; 
+              this->slidingWindowMinhashes.erase(it);   //Remove the entry from the map
+              status = OUT::DEL;
             }
             else
             {
-              this->slidingWindowMinhashes[hashVal].wposR = NAPos;      //Just mark the reference hash absent
-              status = OUT::UPD; 
+              it->second.wposR = NAPos;                 //Just mark the reference hash absent
+              status = OUT::UPD;
             }
           }
           else

--- a/src/map/include/slidingMap.hpp
+++ b/src/map/include/slidingMap.hpp
@@ -230,8 +230,12 @@ namespace skch
          */
         inline void updateCountersAfterInsert(int status, MIIter_t m)
         {
+          // Cache pivot key/value (avoids repeated iterator deref)
+          const hash_t pivotHash = this->pivot->first;
+          const auto &pivotVal = this->pivot->second;
+
           //Revise internal counters
-          if(m->hash <= this->pivot->first)
+          if(m->hash <= pivotHash)
           {
             if(status == IN::CPLD)
             {
@@ -241,14 +245,14 @@ namespace skch
             else if(status == IN::UNIQ)
             {
               //Pivot needs to be decremented
-              if( (this->pivot->second).wposQ != NAPos && (this->pivot->second).wposR != NAPos)
+              if(pivotVal.wposQ != NAPos && pivotVal.wposR != NAPos)
                 this->sharedSketchElements -= 1;
 
               std::advance(this->pivot, -1);
             }
-            else if(status == IN::REV)
+            else
             {
-              //Do nothing
+              // IN::REV -> Do nothing
             }
           }
         }
@@ -260,8 +264,11 @@ namespace skch
          */
         inline void updateCountersAfterDelete(int status, MIIter_t m)
         {
+          // Cache pivot key once (avoid repeated deref)
+          const hash_t pivotHash = this->pivot->first;
+
           //Revise internal counters
-          if(m->hash <= this->pivot->first)
+          if(m->hash <= pivotHash)
           {
             if(status == OUT::UPD)
             {
@@ -273,12 +280,13 @@ namespace skch
               //Pivot needs to be advanced
               std::advance(this->pivot, 1);
 
-              if( (this->pivot->second).wposQ != NAPos && (this->pivot->second).wposR != NAPos)
+              const auto &pivotVal = this->pivot->second;
+              if(pivotVal.wposQ != NAPos && pivotVal.wposR != NAPos)
                 this->sharedSketchElements += 1;
             }
-            else if(status == OUT::NOOP)
+            else
             {
-              //Do nothing
+              // OUT::NOOP -> Do nothing
             }
           }
         }

--- a/src/map/include/slidingMap.hpp
+++ b/src/map/include/slidingMap.hpp
@@ -230,12 +230,8 @@ namespace skch
          */
         inline void updateCountersAfterInsert(int status, MIIter_t m)
         {
-          // Cache pivot key/value (avoids repeated iterator deref)
-          const hash_t pivotHash = this->pivot->first;
-          const auto &pivotVal = this->pivot->second;
-
           //Revise internal counters
-          if(m->hash <= pivotHash)
+          if(m->hash <= this->pivot->first)
           {
             if(status == IN::CPLD)
             {
@@ -245,14 +241,14 @@ namespace skch
             else if(status == IN::UNIQ)
             {
               //Pivot needs to be decremented
-              if(pivotVal.wposQ != NAPos && pivotVal.wposR != NAPos)
+              if( (this->pivot->second).wposQ != NAPos && (this->pivot->second).wposR != NAPos)
                 this->sharedSketchElements -= 1;
 
               std::advance(this->pivot, -1);
             }
-            else
+            else if(status == IN::REV)
             {
-              // IN::REV -> Do nothing
+              //Do nothing
             }
           }
         }
@@ -264,11 +260,8 @@ namespace skch
          */
         inline void updateCountersAfterDelete(int status, MIIter_t m)
         {
-          // Cache pivot key once (avoid repeated deref)
-          const hash_t pivotHash = this->pivot->first;
-
           //Revise internal counters
-          if(m->hash <= pivotHash)
+          if(m->hash <= this->pivot->first)
           {
             if(status == OUT::UPD)
             {
@@ -280,13 +273,12 @@ namespace skch
               //Pivot needs to be advanced
               std::advance(this->pivot, 1);
 
-              const auto &pivotVal = this->pivot->second;
-              if(pivotVal.wposQ != NAPos && pivotVal.wposR != NAPos)
+              if( (this->pivot->second).wposQ != NAPos && (this->pivot->second).wposR != NAPos)
                 this->sharedSketchElements += 1;
             }
-            else
+            else if(status == OUT::NOOP)
             {
-              // OUT::NOOP -> Do nothing
+              //Do nothing
             }
           }
         }

--- a/src/map/include/slidingMap.hpp
+++ b/src/map/include/slidingMap.hpp
@@ -134,32 +134,35 @@ namespace skch
          * @brief               insert a minimizer from the reference sequence into the map
          * @param[in]   m       reference minimizer to insert
          */
-        inline void insert_ref(MIIter_t m)
-        {
-          hash_t hashVal = m->hash;
-          int status;
-
-          auto it = slidingWindowMinhashes.find(hashVal);
-
-          //if hash doesn't exist in the map, add to it
-          if(it == slidingWindowMinhashes.end())
-          {
-            it = slidingWindowMinhashes.emplace(hashVal, slidingMapContainerValueType{this->NAPos, m->wpos}).first;
-            status = IN::UNIQ;
-          }
-          else
-          {
-            status = (it->second.wposR == NAPos) ? IN::CPLD : IN::REV;
-
-            //if hash already exists in the map, just revise it
-            it->second.wposR = m->wpos;
-          }
-
-          updateCountersAfterInsert(status, m);
-
-          assert(this->sharedSketchElements >= 0);
-          assert(this->sharedSketchElements <= Q.sketchSize);
-        }
+         inline void insert_ref(MIIter_t m)
+         {
+           const hash_t hashVal = m->hash;
+           int status;
+         
+           auto it = slidingWindowMinhashes.lower_bound(hashVal);
+         
+           // if hash doesn't exist in the map, add it using the lower_bound hint
+           if(it == slidingWindowMinhashes.end() || it->first != hashVal)
+           {
+             it = slidingWindowMinhashes.emplace_hint(
+                 it,
+                 hashVal,
+                 slidingMapContainerValueType{this->NAPos, m->wpos});
+             status = IN::UNIQ;
+           }
+           else
+           {
+             status = (it->second.wposR == NAPos) ? IN::CPLD : IN::REV;
+         
+             // if hash already exists in the map, just revise it
+             it->second.wposR = m->wpos;
+           }
+         
+           updateCountersAfterInsert(status, m);
+         
+           assert(this->sharedSketchElements >= 0);
+           assert(this->sharedSketchElements <= Q.sketchSize);
+         }
 
         /**
          * @brief               delete a minimizer from the reference sequence from the map

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -147,6 +147,7 @@ namespace skch
 
           //Open the file using kseq
           gzFile fp = gzopen(fileName.c_str(), "r");
+          gzbuffer(fp, 1 << 20);
           kseq_t *seq = kseq_init(fp);
 
           //size of sequence

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -114,6 +114,18 @@ namespace skch
             this->computeFreqHist();
           }
 
+      Sketch(const skch::Parameters &p, bool deferBuild)
+        :
+          param(p)
+      {
+        if(!deferBuild)
+        {
+          this->build();
+          this->index();
+          this->computeFreqHist();
+        }
+      }
+
       private:
 
       /**
@@ -293,6 +305,13 @@ namespace skch
       {
         return this->minimizerIndex.end();
       }
+
+      friend void saveReferenceSketch(const Sketch& sketch,
+                                const Parameters& parameters,
+                                const std::string& outFile);
+
+      friend Sketch loadReferenceSketch(const Parameters& parameters,
+                                        const std::string& inFile);
 
       int getFreqThreshold() const
       {

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -121,20 +121,28 @@ namespace skch
        * @details   compute and save minimizers from the reference sequence(s)
        *            assuming a fixed window size
        */
+
       void build()
       {
 
         //sequence counter while parsing file
         seqno_t seqCounter = 0;
 
+        // PERF: reserve space to avoid repeated reallocations while collecting minimizers
+        // Heuristic: bacterial refs are a few Mbp; windowSize ~ 24; this gives O(2e5-5e5) minimizers.
+        // If this guess is off, reserve() is still safe (just a hint to the allocator).
+        const size_t estMinimizers = 500000;
+        this->minimizerIndex.reserve(estMinimizers);
+
         if ( omp_get_thread_num() == 0)
-          std::cerr << "INFO [thread 0], skch::Sketch::build, window size for minimizer sampling  = " << param.windowSize << std::endl;
+          std::cerr << "INFO [thread 0], skch::Sketch::build, window size for minimizer sampling  = "
+                    << param.windowSize << std::endl;
 
         for(const auto &fileName : param.refSequences)
         {
 
 #ifdef DEBUG
-        std::cerr << "INFO, skch::Sketch::build, building minimizer index for " << fileName << std::endl;
+          std::cerr << "INFO, skch::Sketch::build, building minimizer index for " << fileName << std::endl;
 #endif
 
           //Open the file using kseq
@@ -144,7 +152,7 @@ namespace skch
           //size of sequence
           offset_t len;
 
-          while ((len = kseq_read(seq)) >= 0) 
+          while ((len = kseq_read(seq)) >= 0)
           {
             //Save the sequence name
             metadata.push_back( ContigInfo{seq->name.s, (offset_t)seq->seq.l} );
@@ -166,12 +174,13 @@ namespace skch
 
           sequencesByFileInfo.push_back(seqCounter);
 
-          kseq_destroy(seq);  
-          gzclose(fp); //close the file handler 
+          kseq_destroy(seq);
+          gzclose(fp); //close the file handler
         }
 
         if ( omp_get_thread_num() == 0)
-          std::cerr << "INFO [thread 0], skch::Sketch::build, minimizers picked from reference = " << minimizerIndex.size() << std::endl;
+          std::cerr << "INFO [thread 0], skch::Sketch::build, minimizers picked from reference = "
+                    << minimizerIndex.size() << std::endl;
 
       }
 
@@ -180,16 +189,23 @@ namespace skch
        */
       void index()
       {
+        // PERF: reduce unordered_map rehashing during index build.
+        // Unique minimizers are often a large fraction of total minimizers in bacterial genomes.
+        // Reserving prevents repeated rehash+alloc cycles.
+        const size_t estUnique = std::max<size_t>(1024, this->minimizerIndex.size() / 2);
+        this->minimizerPosLookupIndex.reserve(estUnique);
+
         //Parse all the minimizers and push into the map
         for(auto &e : minimizerIndex)
         {
           // [hash value -> info about minimizer]
-          minimizerPosLookupIndex[e.hash].push_back( 
+          minimizerPosLookupIndex[e.hash].push_back(
               MinimizerMetaData{e.seqId, e.wpos});
         }
 
         if ( omp_get_thread_num() == 0)
-          std::cerr << "INFO [thread 0], skch::Sketch::index, unique minimizers = " << minimizerPosLookupIndex.size() << std::endl;
+          std::cerr << "INFO [thread 0], skch::Sketch::index, unique minimizers = "
+                    << minimizerPosLookupIndex.size() << std::endl;
       }
 
       /**


### PR DESCRIPTION
# PR description

This updates the `fastANI --help` output to make the CLI documentation easier to scan and more task-oriented.

## Changes
- Groups command-line options into four clearly labeled sections:
  - `INPUT OPTIONS`
  - `OUTPUT OPTIONS`
  - `MAPPING PARAMETERS`
  - `EXECUTION OPTIONS`
- Replaces the single generic options block with explicit titled help sections in the rendered man page
- Expands the example usage area with labeled workflow examples for:
  - 1 vs 1 comparison with extended metrics
  - generating a reference sketch from a reference list
  - 1 vs all comparison using a saved sketch with visualization output
  - all vs all comparison using query/reference lists with matrix output
- Improves formatting of the help header:
  - adds `EXAMPLE USAGE` heading
  - inserts spacing between examples
  - cleans up the top description block formatting

### Files changed
- [parseCmdArgs.hpp](/scicomp/home-pure/rqu4/PROJECTS/PERSONAL/FastANI/src/map/include/parseCmdArgs.hpp)

## Validation
- Rebuilt `build/fastANI`
- Verified `./build/fastANI --help` renders the new sections and example formatting correctly